### PR TITLE
Close browser when bot sleeps

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -27,4 +27,10 @@
 
 `Designer, make official logo - January 28, 2018`
 * Twitter: [https://twitter.com/TaniK72](https://twitter.com/TaniK72)
-* Twitter: [https://twitter.com/TaniK72](https://twitter.com/TaniK72)
+
+# Archon (@Archon-) archon.sh@gmail.com
+[![https://twitter.com/_Archon_](https://avatars2.githubusercontent.com/u/1331632?s=150)](https://twitter.com/_Archon_)
+
+`Developer - December 7, 2018`
+* Twitter: [https://twitter.com/_Archon_](https://twitter.com/_Archon_)
+* GitHub: [https://github.com/Archon-](https://github.com/Archon-)

--- a/config.js.tpl
+++ b/config.js.tpl
@@ -24,6 +24,7 @@ module.exports = {
     "chrome_headless": false,
     "chrome_options": ["--disable-gpu", "--no-sandbox", "--window-size=1920x1080"],
     "executable_path": "", // example for Mac OS: /Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome
+    "user_agent": "", // set Puppeteers user agent
 
     // LOG
     "pin_path":"./node_modules/twitterbotlib/loginpin.txt",

--- a/config.js.tpl
+++ b/config.js.tpl
@@ -25,6 +25,8 @@ module.exports = {
     "chrome_options": ["--disable-gpu", "--no-sandbox", "--window-size=1920x1080"],
     "executable_path": "", // example for Mac OS: /Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome
     "user_agent": "", // set Puppeteers user agent
+    "save_session": false, // ability to save browser session to file. Used to restore session when bot closing browser during sleep (see next option - close_browser_sleep) 
+    "close_browser_sleep": false,  // close browser when bot sleeps
 
     // LOG
     "pin_path":"./node_modules/twitterbotlib/loginpin.txt",

--- a/lib.js
+++ b/lib.js
@@ -73,7 +73,7 @@ module.exports = function(config) {
         bot = await browser.newPage();
         bot.setViewport({ "width": 1024, "height": 768 });
         let user_agent = await browser.userAgent();
-        bot.setUserAgent(user_agent.replace("Headless",""));
+        bot.setUserAgent(config.user_agent || "");
 
         /**
          * Import libs

--- a/lib.js
+++ b/lib.js
@@ -97,7 +97,7 @@ module.exports = function(config) {
         async function switch_mode(log) {
             let strategy = routes[config.bot_mode];
             if (strategy !== undefined) {
-                await strategy(bot, config, utils).start();
+                await strategy(bot, config, utils, browser).start();
             } else {
                 log(LOG.ERROR, "switch_mode", `mode ${strategy} not exist!`);
             }

--- a/lib.js
+++ b/lib.js
@@ -73,7 +73,7 @@ module.exports = function(config) {
         bot = await browser.newPage();
         bot.setViewport({ "width": 1024, "height": 768 });
         let user_agent = await browser.userAgent();
-        bot.setUserAgent(config.user_agent || "");
+        bot.setUserAgent(config.user_agent || user_agent.replace("Headless", ""));
 
         /**
          * Import libs

--- a/modules/mode/login.js
+++ b/modules/mode/login.js
@@ -10,6 +10,7 @@
  *
  */
 const Manager_state = require("../common/state").Manager_state;
+const jsonfile = require("jsonfile");
 class Login extends Manager_state {
     constructor(bot, config, utils) {
         super();
@@ -21,6 +22,42 @@ class Login extends Manager_state {
         this.STATE_EVENTS = require("../common/state").EVENTS;
         this.Log = require("../logger/Log");
         this.log = new this.Log(this.LOG_NAME, this.config);
+        this.session = null;
+        this.sessionFilePath = "session.json";
+    }
+
+    /**
+     * Trying read file with session
+     */
+    async read_session_file() {
+        jsonfile.readFile(this.sessionFilePath, (err, data) => {  
+            if (err || data.length === 0) {
+                this.log.info("Cant restore session.");
+            }
+
+            this.session = data;
+        });
+    }
+
+    /**
+     * Check for existing session
+     */
+    session_exists() {
+        return this.session;
+    }
+
+    /**
+     * Restore session
+     */
+    async restore_session() {
+        if (this.session.length !== 0) {
+            for (let cookie of this.session) {
+                await this.bot.setCookie(cookie);
+            }
+
+            return true;
+        }
+        this.log.error("Can't restore session. Session is empty.");
     }
 
     /**
@@ -105,7 +142,21 @@ class Login extends Manager_state {
             await this.utils.screenshot(this.LOG_NAME, "checkerrors_error");
         } else {
             this.log.info("password is correct");
+            
             await this.utils.screenshot(this.LOG_NAME, "checkerrors");
+
+            await this.utils.sleep(this.utils.random_interval(4, 8));
+
+            const cookiesObject = await this.bot.cookies();
+
+            jsonfile.writeFile(this.sessionFilePath, cookiesObject, { spaces: 2 }, (err) => {
+                if (err) {
+                    this.log.info("The file could not be written.", err);
+                    this.emit(this.STATE_EVENTS.CHANGE_STATUS, this.STATE.ERROR);
+                }
+                this.log.info("Session has been successfully saved");
+                this.emit(this.STATE_EVENTS.CHANGE_STATUS, this.STATE.OK);
+            });
         }
 
         await this.utils.sleep(this.utils.random_interval(4, 8));
@@ -119,23 +170,40 @@ class Login extends Manager_state {
     async start() {
         this.log.info("loading...");
 
-        await this.open_loginpage();
+        this.log.info("checking for session to restore...");
+
+        this.log.info("exist: ", this.session_exists());
+
+        await this.read_session_file();
 
         await this.utils.sleep(this.utils.random_interval(4, 8));
 
-        await this.set_username();
+        if (this.session_exists()) {
+            this.log.info("restoring session...");
 
-        await this.utils.sleep(this.utils.random_interval(4, 8));
+            await this.restore_session();
 
-        await this.set_password();
+            this.log.info("Session restored correctly.");
+        } else {
+            await this.open_loginpage();
 
-        await this.utils.sleep(this.utils.random_interval(4, 8));
+            await this.utils.sleep(this.utils.random_interval(4, 8));
 
-        await this.submitform();
+            await this.set_username();
+
+            await this.utils.sleep(this.utils.random_interval(4, 8));
+
+            await this.set_password();
+
+            await this.utils.sleep(this.utils.random_interval(4, 8));
+
+            await this.submitform();
+        }
 
         await this.utils.sleep(this.utils.random_interval(4, 8));
 
         await this.submitverify();
+
         this.log.info("login_status is " + this.get_status());
 
         await this.utils.sleep(this.utils.random_interval(4, 8));

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   "dependencies": {
     "colors": "^1.2.1",
     "eslint": "^4.19.1",
+    "jsonfile": "^5.0.0",
     "path": "^0.12.7",
     "puppeteer": "1.6.2",
     "request": "^2.85.0"


### PR DESCRIPTION
Implementation of issue #13 

This Pull Request present proposal of solution where browser is closed during sleep time for bot. This smart  optimization allow to save some resource (mostly RAM). This is very important for cases when a lot of instances of bots are running.

Was added mechanism of writing session into JSON file. When bot is waking up and browser is open again session is rather recreated from JSON file than login again.

Two new flags in config was added `save_session` and `close_browser_sleep`. Both set to `false` by default to keep backward compatibility. Funtionality is the same as before when keeping both set to `false`.

One new dependency: `jsonfile` - handle session into JSON file.

@ptkdev should this be merged to `master` or `nightly`? No contribution guide at this repo.